### PR TITLE
Bug-Resetting Results After Generation

### DIFF
--- a/Pathfinder Projects/GM-TAR/Disease.cpp
+++ b/Pathfinder Projects/GM-TAR/Disease.cpp
@@ -101,5 +101,15 @@ list<string> Disease::GetResults()
 		}
 	}
 
+	ResetTable();
 	return results;
+}
+
+void Disease::ResetTable()
+{
+	for (int i = 0; i < players.size(); i++)
+	{
+		players.at(i).daysSick.clear();
+		players.at(i).percentAmount.clear();
+	}
 }

--- a/Pathfinder Projects/GM-TAR/Disease.h
+++ b/Pathfinder Projects/GM-TAR/Disease.h
@@ -38,6 +38,7 @@ public:
 	void SetPercentChance(int);
 	void GenerateDisease();
 	list<string> GetResults();
+	void ResetTable();
 };
 
 #endif

--- a/Pathfinder Projects/GM-TAR/Encounter.cpp
+++ b/Pathfinder Projects/GM-TAR/Encounter.cpp
@@ -99,5 +99,12 @@ list<string> Encounter::GetResults()
 		results.push_back(statement);
 	}
 
+	ResetTable();
+
 	return results;
+}
+
+void Encounter::ResetTable()
+{
+	encounters.clear();
 }

--- a/Pathfinder Projects/GM-TAR/Encounter.h
+++ b/Pathfinder Projects/GM-TAR/Encounter.h
@@ -92,6 +92,7 @@ public:
 	void SetDayCount(int);
 	void SetPercentChance(int);
 	list<string> GetResults();
+	void ResetTable();
 };
 
 #endif


### PR DESCRIPTION
Reset the vectors upon presenting the results, creating a resetting cycle.